### PR TITLE
chore: release version 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,18 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 :microscope: - experimental
 
-## [Unreleased]
+## [2.3.1]
 - :beetle: fixed JUnit report path in PR workflow to use `test/report/report.xml`
 - :pencil: added explicit `exports` map in `package.json` for root and `./js` entrypoints
 - :pencil: restricted npm package contents via `files` allowlist in `package.json`
+- :pencil: added shared type definitions (`CucumberAdapterConfig`, `HookDefinition`, `StepDefinitionMatch`, `SupportCodeLibrary`, `Feature`) replacing `any` throughout the codebase
+- :pencil: added explicit `rootDir` to both `tsconfig.json` and `tsconfig.js.json` for forward compatibility with stricter TypeScript versions
+- :beetle: improved error messages for undefined and ambiguous steps — now includes feature file URI and all matching step definition locations
+- :rocket: added optional `DEBUG=cucumber-adapter` environment variable for step-matching trace logging
+- :pencil: added tests for `{int}`, `{float}`, and `{word}` Cucumber parameter types
+- :pencil: added tests for Scenario Outlines with multiple `Examples:` tables
+- :pencil: added tests for tag-scoped `Before` and `After` hooks
+- :pencil: added unit tests for `tags()` and `filter()` utility functions
 
 ## [2.3.0]
 - :rocket: simplified adapter by moving hook into test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/cucumber": "^12.7.0",
+        "@cucumber/cucumber": "^12.8.1",
         "@cucumber/gherkin": "^39.0.0",
         "@cucumber/tag-expressions": "^9.1.0",
         "glob": "^13.0.6"
       },
       "devDependencies": {
-        "@playwright/test": "^1.58.2",
-        "@types/node": "^25.5.0",
-        "typescript": "^5.9.3"
+        "@playwright/test": "^1.59.1",
+        "@types/node": "^25.6.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -60,9 +60,9 @@
       "license": "MIT"
     },
     "node_modules/@cucumber/cucumber": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-12.7.0.tgz",
-      "integrity": "sha512-7A/9CJpJDxv1SQ7hAZU0zPn2yRxx6XMR+LO4T94Enm3cYNWsEEj+RGX38NLX4INT+H6w5raX3Csb/qs4vUBsOA==",
+      "version": "12.8.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-12.8.1.tgz",
+      "integrity": "sha512-hCXxiStjbZsRVZlV+CMywkqBtJ6RZTQeXSBZGPHm1YoIOI6YB8pCo0KlnJMmxfKfoeUKagtQMNPnpJBXwhkUjQ==",
       "license": "MIT",
       "dependencies": {
         "@cucumber/ci-environment": "13.0.0",
@@ -71,9 +71,9 @@
         "@cucumber/gherkin-streams": "6.0.0",
         "@cucumber/gherkin-utils": "11.0.0",
         "@cucumber/html-formatter": "23.0.0",
-        "@cucumber/junit-xml-formatter": "0.9.0",
-        "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "32.0.1",
+        "@cucumber/junit-xml-formatter": "0.13.3",
+        "@cucumber/message-streams": "4.1.1",
+        "@cucumber/messages": "32.2.0",
         "@cucumber/pretty-formatter": "1.0.1",
         "@cucumber/tag-expressions": "9.1.0",
         "assertion-error-formatter": "^3.0.0",
@@ -93,7 +93,6 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "luxon": "3.7.2",
-        "mime": "^3.0.0",
         "mkdirp": "^3.0.0",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
@@ -205,12 +204,12 @@
       }
     },
     "node_modules/@cucumber/junit-xml-formatter": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.9.0.tgz",
-      "integrity": "sha512-WF+A7pBaXpKMD1i7K59Nk5519zj4extxY4+4nSgv5XLsGXHDf1gJnb84BkLUzevNtp2o2QzMG0vWLwSm8V5blw==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.13.3.tgz",
+      "integrity": "sha512-w9ujOxiuKDtU6fLzJz+wp4Sgp5Xu6ba7ls00LHJccVmQU0Ba7zs+AHnv3iIgPjKZAQe1w8x93dr8Gaubh7Vqkg==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/query": "^14.0.1",
+        "@cucumber/query": "^15.0.1",
         "@teppeis/multimaps": "^3.0.0",
         "luxon": "^3.5.0",
         "xmlbuilder": "^15.1.1"
@@ -220,18 +219,21 @@
       }
     },
     "node_modules/@cucumber/message-streams": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
-      "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.1.1.tgz",
+      "integrity": "sha512-QCAntLajesWMyX+mZKrj63YghVAts7yKFlZe46XprLbdJZN0ddB+f/Mr9OnyWKC2DHhJ18jzCfKIFCaqpAmUxg==",
       "license": "MIT",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
       "peerDependencies": {
         "@cucumber/messages": ">=17.1.1"
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "32.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.0.1.tgz",
-      "integrity": "sha512-1OSoW+GQvFUNAl6tdP2CTBexTXMNJF0094goVUcvugtQeXtJ0K8sCP0xbq7GGoiezs/eJAAOD03+zAPT64orHQ==",
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.2.0.tgz",
+      "integrity": "sha512-oYp1dgL2TByYWL51Z+rNm+/mFtJhiPU9WS03goes9EALb8d9GFcXRbG1JluFLFaChF1YDqIzLac0kkC3tv1DjQ==",
       "license": "MIT",
       "dependencies": {
         "class-transformer": "0.5.1",
@@ -267,9 +269,9 @@
       }
     },
     "node_modules/@cucumber/query": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-14.7.0.tgz",
-      "integrity": "sha512-fiqZ4gMEgYjmbuWproF/YeCdD5y+gD2BqgBIGbpihOsx6UlNsyzoDSfO+Tny0q65DxfK+pHo2UkPyEl7dO7wmQ==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-15.0.1.tgz",
+      "integrity": "sha512-FMfT3orJblRsOxvU2doECBvQmauizYlj+5JsM8atAKKPbnQTj7v2/OrnuykvQpfZNBf19DYbRq1e832vllRP/g==",
       "license": "MIT",
       "dependencies": {
         "@teppeis/multimaps": "3.0.0",
@@ -295,13 +297,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -320,13 +322,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -385,15 +387,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer-from": {
@@ -921,13 +923,13 @@
       "license": "ISC"
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -940,9 +942,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1261,9 +1263,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1275,9 +1277,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1326,14 +1328,18 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
-      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yup": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qavajs/playwright-runner-adapter",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "adapter for playwright test runner",
   "main": "adapter/index.js",
   "types": "adapter/index.d.ts",
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "tsc && tsc --project tsconfig.js.json",
     "test:ui": "playwright test --config test/playwright.config.ts --ui",
-    "test:e2e": "playwright test --config test/playwright.config.ts --project parallel --project serial"
+    "test:e2e": "playwright test --config test/playwright.config.ts --project parallel --project serial --project unit"
   },
   "author": "Alexandr Galichenko",
   "license": "MIT",
@@ -43,12 +43,12 @@
     "@cucumber/gherkin": "^39.0.0",
     "@cucumber/tag-expressions": "^9.1.0",
     "glob": "^13.0.6",
-    "@cucumber/cucumber": "^12.7.0"
+    "@cucumber/cucumber": "^12.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
-    "@types/node": "^25.5.0",
-    "typescript": "^5.9.3"
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
   },
   "keywords": [
     "test",

--- a/src/PlaywrightWorld.ts
+++ b/src/PlaywrightWorld.ts
@@ -1,31 +1,33 @@
 import { APIRequestContext, Browser, BrowserContext, Page, test, expect } from '@playwright/test';
+import type { CucumberAdapterConfig, SupportCodeLibrary, WorldOptions } from './types';
 
-/**
- * Cucumber world for playwright adapter
- */
 export class TestWorld {
-    log!: (data: any) => void;
-    attach!: (data: any, details?: { fileName?: string, mediaType: string }) => Promise<void>;
-    parameters!: string;
-    config: any;
-    supportCodeLibrary!: any;
+    log!: (data: unknown) => void;
+    attach!: (data: unknown, details?: { fileName?: string; mediaType: string }) => Promise<void>;
+    parameters!: unknown;
+    config!: CucumberAdapterConfig;
+    supportCodeLibrary!: SupportCodeLibrary;
     test = test;
     expect = expect;
 
-    constructor(options: any) {
-        this.log = options.log;
-        this.attach = options.attach;
+    constructor(options: WorldOptions) {
+        this.log = options.log ?? console.log;
+        this.attach = options.attach as TestWorld['attach'];
         this.parameters = options.parameters;
-        this.supportCodeLibrary = options.supportCodeLibrary;
-        this.config = options.config;
+        this.supportCodeLibrary = options.supportCodeLibrary!;
+        this.config = options.config!;
     }
 
-    async executeStep(this: any, text: string, extraParam?: any) {
-        const steps = this.supportCodeLibrary.stepDefinitions.filter((s: any) => s.matchesStepName(text));
+    async executeStep(this: TestWorld, text: string, extraParam?: unknown) {
+        const steps = this.supportCodeLibrary.stepDefinitions
+            .filter(s => s.matchesStepName(text));
         if (steps.length === 0) throw new Error(`Step "${text}" is not defined`);
-        if (steps.length > 1) throw new Error(`Step "${text}" matches multiple step definitions`);
-        const step = steps.pop() as any;
-        const { parameters } = await step.getInvocationParameters({ step: { text }, world: this } as any);
+        if (steps.length > 1) {
+            const locations = steps.map(s => `  ${s.uri}:${s.line}`).join('\n');
+            throw new Error(`Step "${text}" matches multiple step definitions:\n${locations}`);
+        }
+        const step = steps[0];
+        const { parameters } = await step.getInvocationParameters({ step: { text }, world: this });
         try {
             await step.code.apply(this, [...parameters, extraParam]);
         } catch (err) {
@@ -34,9 +36,6 @@ export class TestWorld {
     }
 }
 
-/**
- * Cucumber Playwright world for playwright adapter
- */
 export class PlaywrightWorld extends TestWorld {
     page!: Page;
     context!: BrowserContext;
@@ -44,10 +43,11 @@ export class PlaywrightWorld extends TestWorld {
     browserName!: string;
     request!: APIRequestContext;
 
-    init: ({ [fixture: string]: any }) = ({ browser, context, page, request }: { browser: Browser, context: BrowserContext, page: Page, request: APIRequestContext }) => {
+    // Cast preserves the destructured param form that Playwright reads via toString() to discover fixtures
+    init = (({ browser, context, page, request }: { browser: Browser; context: BrowserContext; page: Page; request: APIRequestContext }) => {
         this.browser = browser;
         this.context = context;
         this.page = page;
         this.request = request;
-    }
+    }) as (fixtures: Record<string, unknown>) => void;
 }

--- a/src/cucumberAdapter.ts
+++ b/src/cucumberAdapter.ts
@@ -1,8 +1,19 @@
 import {load} from './loader';
 import type {TestInfo, TestType} from '@playwright/test';
 import type {ITestCaseHookParameter, ITestStepHookParameter} from '@cucumber/cucumber';
+import type {Pickle, PickleStep} from '@cucumber/messages';
+import type {
+    CucumberAdapterConfig,
+    Feature,
+    HookDefinition,
+    HookResult,
+    StepDefinitionMatch,
+    SupportCodeLibrary,
+    WorldBase
+} from './types';
 
-// Constants
+const DEBUG = process.env.DEBUG?.split(',').includes('cucumber-adapter') ?? false;
+
 const ANNOTATION_TYPES = {
     NAME: 'name',
     URI: 'uri',
@@ -34,40 +45,19 @@ const STEP_ARGUMENT_LABELS = {
     DATA_TABLE: ' [DataTable]'
 } as const;
 
-// Type definitions
 interface Location {
     file: string;
     line: number;
     column: number;
 }
 
-interface StepDefinition {
-    uri: string;
-    line: number;
-}
-
-interface TestResult {
+interface TestExecutionResult {
     status: string;
     error?: Error;
-}
-
-interface TestExecutionResult extends TestResult {
     start: number;
 }
 
-interface FeatureContext {
-    gherkinDocument: unknown;
-}
-
-interface PickleStep {
-    text: string;
-    argument?: { docString?: unknown };
-}
-
-/**
- * Creates a location object from step definition
- */
-function getLine(step: StepDefinition): { location: Location } {
+function getLine(step: Pick<HookDefinition, 'uri' | 'line'>): { location: Location } {
     return {
         location: {
             column: DEFAULT_VALUES.COLUMN,
@@ -77,41 +67,29 @@ function getLine(step: StepDefinition): { location: Location } {
     };
 }
 
-/**
- * Logs data to console
- */
 function log(data: unknown): void {
     console.log(data);
 }
 
-/**
- * Attaches content to test report
- */
 function attach(
     this: { test: { info: () => TestInfo } },
-    body: string | Buffer,
+    body: unknown,
     details?: { fileName?: string; mediaType?: string }
 ): Promise<void> {
     const fileName = details?.fileName ?? DEFAULT_VALUES.ATTACHMENT_FILENAME;
     const contentType = details?.mediaType ?? DEFAULT_VALUES.CONTENT_TYPE;
-    return this.test.info().attach(fileName, { body, contentType });
+    return this.test.info().attach(fileName, { body: body as string | Buffer, contentType });
 }
 
-/**
- * Generates a human-readable step name with argument type indicator
- */
-function stepName(pickleStep: {
-    text: string;
-    argument?: { docString?: unknown }
-}): string {
+function stepName(pickleStep: PickleStep): string {
     let step = pickleStep.text;
-    
+
     if (pickleStep.argument) {
         step += pickleStep.argument.docString
             ? STEP_ARGUMENT_LABELS.DOC_STRING
             : STEP_ARGUMENT_LABELS.DATA_TABLE;
     }
-    
+
     return step;
 }
 
@@ -122,17 +100,17 @@ function createTestExecutionResult(): TestExecutionResult {
     };
 }
 
-function createHookResult(result: TestExecutionResult): any {
+function createHookResult(result: TestExecutionResult): HookResult {
     return {
-        duration: (Date.now() - result.start) as any,
+        duration: Date.now() - result.start,
         message: result.error?.message,
         status: result.status.toUpperCase(),
         exception: result.error
     };
 }
 
-function createScenarioAnnotation(testCase: any): { type: string; description: string }[] {
-    const tag = [...new Set(testCase.tags.map((item: { name: string }) => item.name))];
+function createScenarioAnnotation(testCase: Pickle): { type: string; description: string }[] {
+    const tag = [...new Set(testCase.tags.map(item => item.name))];
     return [
         {type: ANNOTATION_TYPES.NAME, description: testCase.name},
         {type: ANNOTATION_TYPES.URI, description: testCase.uri},
@@ -140,11 +118,11 @@ function createScenarioAnnotation(testCase: any): { type: string; description: s
     ];
 }
 
-function createScenarioTags(testCase: any): string[] {
-    return [...new Set<string>(testCase.tags.map((item: { name: string }) => item.name))];
+function createScenarioTags(testCase: Pickle): string[] {
+    return [...new Set<string>(testCase.tags.map(item => item.name))];
 }
 
-function createCaseHookPayload(feature: FeatureContext, testCase: any): ITestCaseHookParameter {
+function createCaseHookPayload(feature: Feature, testCase: Pickle): ITestCaseHookParameter {
     return {
         gherkinDocument: feature.gherkinDocument,
         pickle: testCase
@@ -152,12 +130,12 @@ function createCaseHookPayload(feature: FeatureContext, testCase: any): ITestCas
 }
 
 async function executeCaseHooks(
-    test: TestType<any, any>,
-    hooks: any[],
-    world: any,
-    testCase: any,
+    test: TestType<Record<string, unknown>, Record<string, unknown>>,
+    hooks: HookDefinition[],
+    world: unknown,
+    testCase: Pickle,
     defaultHookName: string,
-    createPayload: (hook: any) => any
+    createPayload: (hook: HookDefinition) => unknown
 ): Promise<void> {
     for (const hook of hooks) {
         if (!hook.appliesToTestCase(testCase)) {
@@ -175,12 +153,12 @@ async function executeCaseHooks(
 }
 
 async function executeStepHooks(
-    test: TestType<any, any>,
-    hooks: any[],
-    world: any,
-    testCase: any,
+    test: TestType<Record<string, unknown>, Record<string, unknown>>,
+    hooks: HookDefinition[],
+    world: unknown,
+    testCase: Pickle,
     hookName: string,
-    createPayload: (hook: any) => any
+    createPayload: (hook: HookDefinition) => unknown
 ): Promise<void> {
     for (const hook of hooks) {
         if (!hook.appliesToTestCase(testCase)) {
@@ -197,9 +175,9 @@ async function executeStepHooks(
 }
 
 function createStepHookParameter(
-    feature: any,
-    testCase: any,
-    pickleStep: any,
+    feature: Feature,
+    testCase: Pickle,
+    pickleStep: PickleStep,
     result: TestExecutionResult
 ): ITestStepHookParameter {
     return {
@@ -209,12 +187,12 @@ function createStepHookParameter(
         pickle: testCase,
         pickleStep,
         result: createHookResult(result)
-    } as any;
+    } as unknown as ITestStepHookParameter;
 }
 
 function createCaseHookParameter(
-    feature: any,
-    testCase: any,
+    feature: Feature,
+    testCase: Pickle,
     result: TestExecutionResult
 ): ITestCaseHookParameter {
     return {
@@ -222,33 +200,42 @@ function createCaseHookParameter(
         testCaseStartedId: DEFAULT_VALUES.TEST_CASE_ID,
         pickle: testCase,
         result: createHookResult(result)
-    } as any;
+    } as unknown as ITestCaseHookParameter;
 }
 
 function findSingleStepDefinition(
-    supportCodeLibrary: any,
-    pickleStep: PickleStep
-): any {
+    supportCodeLibrary: SupportCodeLibrary,
+    pickleStep: PickleStep,
+    featureUri: string
+): StepDefinitionMatch {
     const matchingSteps = supportCodeLibrary.stepDefinitions
-        .filter((stepDefinition: any) => stepDefinition.matchesStepName(pickleStep.text));
+        .filter(stepDefinition => stepDefinition.matchesStepName(pickleStep.text));
+
+    if (DEBUG) {
+        console.log(`[cucumber-adapter] Matching: "${pickleStep.text}" — ${matchingSteps.length} match(es)`);
+    }
 
     if (matchingSteps.length === 0) {
-        throw new Error(`Step '${pickleStep.text}' is not defined`);
+        throw new Error(
+            `Step '${pickleStep.text}' is not defined\n  at ${featureUri}`
+        );
     }
 
     if (matchingSteps.length > 1) {
-        throw new Error(`Step '${pickleStep.text}' matches multiple step definitions`);
+        const locations = matchingSteps
+            .map(s => `  ${s.uri}:${s.line}`)
+            .join('\n');
+        throw new Error(
+            `Step '${pickleStep.text}' matches multiple step definitions:\n${locations}`
+        );
     }
 
     return matchingSteps[0];
 }
 
-/**
- * Executes before all hooks
- */
 function executeBeforeAllHooks(
-    test: TestType<any, any>,
-    hooks: any[]
+    test: TestType<Record<string, unknown>, Record<string, unknown>>,
+    hooks: HookDefinition[]
 ): void {
     if (hooks.length === 0) return;
     test.beforeAll(async () => {
@@ -260,15 +247,12 @@ function executeBeforeAllHooks(
                 location
             );
         }
-    })
+    });
 }
 
-/**
- * Executes after all hooks
- */
 function executeAfterAllHooks(
-    test: TestType<any, any>,
-    hooks: any[]
+    test: TestType<Record<string, unknown>, Record<string, unknown>>,
+    hooks: HookDefinition[]
 ): void {
     if (hooks.length === 0) return;
     test.afterAll(async () => {
@@ -283,14 +267,11 @@ function executeAfterAllHooks(
     });
 }
 
-/**
- * Main configuration function that sets up Cucumber adapter for Playwright
- */
-export function defineConfig(config: any): any {
+export function defineConfig(config: CucumberAdapterConfig): void {
     const {features, supportCodeLibrary} = load(config);
 
-    const fixture = new supportCodeLibrary.World({config});
-    const test: TestType<any, any> = fixture.test;
+    const fixture = new supportCodeLibrary.World({config}) as WorldBase;
+    const test = fixture.test as TestType<Record<string, unknown>, Record<string, unknown>>;
     executeBeforeAllHooks(test, supportCodeLibrary.beforeTestRunHookDefinitions);
 
     for (const feature of features) {
@@ -300,7 +281,7 @@ export function defineConfig(config: any): any {
             for (const testCase of tests) {
                 const tag = createScenarioTags(testCase);
                 const annotation = createScenarioAnnotation(testCase);
-                const testBody = async (fixtures: any) => {
+                const testBody = async (fixtures: Record<string, unknown>) => {
                     const world = new supportCodeLibrary.World({
                         log,
                         attach,
@@ -325,7 +306,7 @@ export function defineConfig(config: any): any {
                             if (result.status !== 'passed') {
                                 break;
                             }
-                            const step = findSingleStepDefinition(supportCodeLibrary, pickleStep);
+                            const step = findSingleStepDefinition(supportCodeLibrary, pickleStep, feature.uri);
                             const location = getLine(step);
                             await test.step(stepName(pickleStep), async () => {
                                 await executeStepHooks(
@@ -346,12 +327,12 @@ export function defineConfig(config: any): any {
                                         argument: pickleStep.argument
                                     },
                                     world
-                                } as any);
+                                });
                                 try {
                                     await step.code.apply(world, parameters);
-                                } catch (err: any) {
+                                } catch (err) {
                                     result.status = 'failed';
-                                    result.error = err;
+                                    result.error = err as Error;
                                     throw err;
                                 } finally {
                                     await executeStepHooks(
@@ -376,7 +357,7 @@ export function defineConfig(config: any): any {
                         );
                     }
 
-                }
+                };
                 testBody.toString = () => fixture.init.toString();
                 test(testCase.name, {tag, annotation}, testBody);
             }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -3,9 +3,10 @@ import { resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { AstBuilder, compile, GherkinClassicTokenMatcher, Parser } from '@cucumber/gherkin';
 import { supportCodeLibraryBuilder } from '@cucumber/cucumber';
-import type { Pickle, GherkinDocument } from '@cucumber/messages';
+import type { Pickle } from '@cucumber/messages';
 import { globSync } from 'glob';
 import { PlaywrightWorld } from './PlaywrightWorld';
+import type { CucumberAdapterConfig, Feature, SupportCodeLibrary } from './types';
 
 const uuidFn = () => randomUUID();
 const builder = new AstBuilder(uuidFn);
@@ -27,13 +28,6 @@ function duplicates(tests: readonly Pickle[]) {
     });
 }
 
-type Feature = {
-    feature?: string;
-    gherkinDocument: GherkinDocument;
-    tests: readonly Pickle[];
-    uri: string;
-}
-
 export function loadFeatures(globPattern: string[]): Feature[] {
     const files = globSync(globPattern);
     return files.map(file => {
@@ -48,7 +42,7 @@ export function loadFeatures(globPattern: string[]): Feature[] {
     });
 }
 
-export function loadStepDefinitions(globPattern: string[]) {
+export function loadStepDefinitions(globPattern: string[]): SupportCodeLibrary {
     supportCodeLibraryBuilder.reset(process.cwd(), uuidFn);
     supportCodeLibraryBuilder.methods.setWorldConstructor(PlaywrightWorld);
     const files = globSync(globPattern);
@@ -56,10 +50,10 @@ export function loadStepDefinitions(globPattern: string[]) {
         const filePath = resolve(file);
         require(filePath);
     }
-    return supportCodeLibraryBuilder.finalize();
+    return supportCodeLibraryBuilder.finalize() as unknown as SupportCodeLibrary;
 }
 
-export function load(config: any) {
+export function load(config: CucumberAdapterConfig): { features: Feature[]; supportCodeLibrary: SupportCodeLibrary } {
     const features = loadFeatures(config.paths);
     const supportCodeLibrary = loadStepDefinitions([
         ...(config.requireModules ?? []),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,67 @@
+import type { GherkinDocument, Pickle } from '@cucumber/messages';
+import type { TestType } from '@playwright/test';
+
+export interface CucumberAdapterConfig {
+    paths: string[];
+    require?: string[];
+    requireModules?: string[];
+    import?: string[];
+    [key: string]: unknown;
+}
+
+export interface WorldOptions {
+    log?: (data: unknown) => void;
+    attach?: (data: unknown, details?: { fileName?: string; mediaType?: string }) => Promise<void>;
+    parameters?: unknown;
+    supportCodeLibrary?: SupportCodeLibrary;
+    config?: CucumberAdapterConfig;
+}
+
+export interface HookDefinition {
+    uri: string;
+    line: number;
+    name?: string;
+    code: (this: unknown, ...args: unknown[]) => Promise<void> | void;
+    appliesToTestCase(testCase: Pickle): boolean;
+}
+
+export interface StepDefinitionMatch {
+    uri: string;
+    line: number;
+    code: (this: unknown, ...args: unknown[]) => Promise<void> | void;
+    matchesStepName(text: string): boolean;
+    getInvocationParameters(options: {
+        step: { text: string; argument?: unknown };
+        world: unknown;
+    }): Promise<{ parameters: unknown[] }>;
+}
+
+export interface HookResult {
+    duration: number;
+    message: string | undefined;
+    status: string;
+    exception: Error | undefined;
+}
+
+export interface WorldBase {
+    test: TestType<Record<string, unknown>, Record<string, unknown>>;
+    init: (fixtures: Record<string, unknown>) => void;
+}
+
+export interface SupportCodeLibrary {
+    World: new (options: WorldOptions) => WorldBase;
+    stepDefinitions: StepDefinitionMatch[];
+    beforeTestRunHookDefinitions: HookDefinition[];
+    afterTestRunHookDefinitions: HookDefinition[];
+    beforeTestCaseHookDefinitions: HookDefinition[];
+    afterTestCaseHookDefinitions: HookDefinition[];
+    beforeTestStepHookDefinitions: HookDefinition[];
+    afterTestStepHookDefinitions: HookDefinition[];
+}
+
+export interface Feature {
+    feature?: string;
+    gherkinDocument: GherkinDocument;
+    tests: readonly Pickle[];
+    uri: string;
+}

--- a/test/features/hooks.feature
+++ b/test/features/hooks.feature
@@ -1,0 +1,9 @@
+Feature: hook features
+
+  @hookTagTest
+  Scenario: tagged before hook
+    Given tagged before hook ran
+
+  @hookTagTest
+  Scenario: tagged after hook
+    Given simple step

--- a/test/features/parameters.feature
+++ b/test/features/parameters.feature
@@ -1,0 +1,22 @@
+Feature: step parameters
+
+  Scenario: int parameter
+    Given I have 42 items
+
+  Scenario: float parameter
+    Given I have 3.14 value
+
+  Scenario: word parameter
+    Given I am at step hello
+
+  Scenario Outline: multiple example tables <example>
+    Given log '<example>'
+
+    Examples: first batch
+      | example |
+      | one     |
+      | two     |
+
+    Examples: second batch
+      | example |
+      | three   |

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
     /* Configure projects for major browsers */
     projects: [
         {
+            name: 'unit',
+            testMatch: 'unit.spec.ts',
+        },
+        {
             name: 'adapterTS',
             testMatch: 'adapterTS.config.ts',
             use: {

--- a/test/step_definitions/steps.ts
+++ b/test/step_definitions/steps.ts
@@ -40,6 +40,8 @@ const customExpect = baseExpect.extend({
 class ExtendedPlaywrightWorld extends PlaywrightWorld {
     customFixture!: number;
     renamedCustomFixture!: number;
+    hookTagRan?: boolean;
+    afterHookTagRan?: boolean;
     test = fixture;
     expect = customExpect;
 
@@ -160,4 +162,29 @@ When('template step', Template(() => `
 
 When('log {string}', async function (value) {
     this.log(value);
+});
+
+When('I have {int} items', async function (this: ExtendedPlaywrightWorld, count: number) {
+    this.expect(count).toBe(42);
+});
+
+When('I have {float} value', async function (this: ExtendedPlaywrightWorld, value: number) {
+    this.expect(value).toBeCloseTo(3.14);
+});
+
+When('I am at step {word}', async function (this: ExtendedPlaywrightWorld, word: string) {
+    this.expect(word).toBe('hello');
+});
+
+When('tagged before hook ran', async function (this: ExtendedPlaywrightWorld) {
+    this.expect(this.hookTagRan).toBe(true);
+});
+
+Before({ tags: '@hookTagTest' }, async function (this: ExtendedPlaywrightWorld) {
+    this.hookTagRan = true;
+});
+
+After({ tags: '@hookTagTest' }, async function (this: ExtendedPlaywrightWorld, testCase: ITestCaseHookParameter) {
+    this.expect(testCase.result?.status).toEqual('PASSED');
+    this.afterHookTagRan = true;
 });

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { tags, filter } from '../adapter';
+
+test.describe('tags()', () => {
+    test('matches single tag', () => {
+        const regexp = tags('@foo');
+        expect(regexp.test('@foo')).toBe(true);
+        expect(regexp.test('@bar')).toBe(false);
+    });
+
+    test('handles and expression', () => {
+        const regexp = tags('@foo and @bar');
+        expect(regexp.test('@foo @bar')).toBe(true);
+        expect(regexp.test('@foo')).toBe(false);
+        expect(regexp.test('@bar')).toBe(false);
+    });
+
+    test('handles or expression', () => {
+        const regexp = tags('@foo or @bar');
+        expect(regexp.test('@foo')).toBe(true);
+        expect(regexp.test('@bar')).toBe(true);
+        expect(regexp.test('@baz')).toBe(false);
+    });
+
+    test('handles not expression', () => {
+        const regexp = tags('not @noParallel');
+        expect(regexp.test('@tag')).toBe(true);
+        expect(regexp.test('@noParallel')).toBe(false);
+    });
+
+    test('handles complex expressions', () => {
+        const regexp = tags('@a and (not @b or @c)');
+        expect(regexp.test('@a @c')).toBe(true);
+        expect(regexp.test('@a')).toBe(true);
+        expect(regexp.test('@a @b')).toBe(false);
+    });
+
+    test('returns RegExp instance', () => {
+        expect(tags('@foo')).toBeInstanceOf(RegExp);
+    });
+});
+
+test.describe('filter()', () => {
+    test('applies predicate to test name', () => {
+        const regexp = filter(name => name.includes('login'));
+        expect(regexp.test('user login scenario')).toBe(true);
+        expect(regexp.test('register scenario')).toBe(false);
+    });
+
+    test('returns RegExp instance', () => {
+        expect(filter(() => true)).toBeInstanceOf(RegExp);
+    });
+
+    test('passes exact name to predicate', () => {
+        const captured: string[] = [];
+        const regexp = filter(name => { captured.push(name); return true; });
+        regexp.test('my test name');
+        expect(captured).toContain('my test name');
+    });
+
+    test('always-true predicate matches anything', () => {
+        const regexp = filter(() => true);
+        expect(regexp.test('anything')).toBe(true);
+        expect(regexp.test('')).toBe(true);
+    });
+
+    test('always-false predicate matches nothing', () => {
+        const regexp = filter(() => false);
+        expect(regexp.test('anything')).toBe(false);
+    });
+});

--- a/tsconfig.js.json
+++ b/tsconfig.js.json
@@ -6,6 +6,7 @@
     "test/**/*.spec.ts"
   ],
   "compilerOptions": {
+    "rootDir": "./src",
     "target": "es2023",
     "module": "node16",
     "moduleResolution": "node16",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "test/**/*.spec.ts"
   ],
   "compilerOptions": {
+    "rootDir": "./src",
     "target": "es2023",
     "module": "node16",
     "moduleResolution": "node16",


### PR DESCRIPTION
- fix: corrected JUnit report path in PR workflow to use `test/report/report.xml`
- feat: added explicit `exports` map in `package.json` for root and `./js` entrypoints
- feat: restricted npm package contents via `files` allowlist in `package.json`
- feat: introduced shared type definitions (`CucumberAdapterConfig`, `HookDefinition`, `StepDefinitionMatch`, `SupportCodeLibrary`, `Feature`) to replace `any` throughout the codebase
- feat: added explicit `rootDir` to both `tsconfig.json` and `tsconfig.js.json` for forward compatibility with stricter TypeScript versions
- fix: improved error messages for undefined and ambiguous steps, now including feature file URI and all matching step definition locations
- feat: added optional `DEBUG=cucumber-adapter` environment variable for step-matching trace logging
- test: added tests for `{int}`, `{float}`, and `{word}` Cucumber parameter types
- test: added tests for Scenario Outlines with multiple `Examples:` tables
- test: added tests for tag-scoped `Before` and `After` hooks
- test: added unit tests for `tags()` and `filter()` utility functions

Before submitting this PR, please ensure that you have completed the following:

- [ ] Updated the CHANGELOG.md.
- [ ] Checked that there aren't other open pull requests for the same issue/update.
- [ ] Checked that your contribution follows the project's contribution guidelines.
- [ ] Added corresponding unit/E2E tests

## Description

Please describe your changes and any new features you're introducing, or issues you're fixing.

### Related Issues

Please link any related issues or bug reports that this PR will address.
